### PR TITLE
Restore requirements section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ v0.3
 
 ---
 
+## Requirements
+
+- [CBQN](https://github.com/dzaima/CBQN)
+- Python 3 + `pip install yfinance` (for data fetching)
+
 ## Overview
 
 bbq is a toolkit for quantitative strategy development in BQN.


### PR DESCRIPTION
## Summary

- Add back Requirements section (CBQN, Python 3 + yfinance) dropped in b7e2bcb

🤖 Generated with [Claude Code](https://claude.com/claude-code)