### PR TITLE
perf/refresh: O(n) rolling stats, dead-code cleanup, doc accuracy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,12 +80,18 @@ regime filters) and emits a position array that feeds the same `Run` pipeline.
 
 ## Performance
 
-The indicator and rolling layers should be **O(n)**, not O(n·window):
+The indicator and rolling layers are **O(n)**, not O(n·window). Rolling sums,
+means, and variances use prefix sums instead of recomputing each window from
+scratch:
 
-- Rolling sums/means/variances use **prefix sums** (`cs ← 0∾+`x`, then window
-  sum `= (n↓cs) - (-n)↓cs`). See `MA`/`Std` in `core.bqn` and `RSharpe`/`RVol`/
-  `RBeta` in `roll.bqn`, `VolTarget` in `risk.bqn`. Sample variance is
-  `(Σx² - (Σx)²/n)/(n-1)`; clamp with `√0⌈…` to absorb cancellation noise.
+```bqn
+cs   ← 0∾+`x                 # prefix sum, computed once
+wsum ← (n↓cs) - (-n)↓cs      # every length-n window sum, in one shot
+```
+
+- Sample variance is `(Σx² - (Σx)²/n)/(n-1)`; clamp with `√0⌈…` to absorb
+  cancellation noise. See `MA`/`Std` in `core.bqn`, `RSharpe`/`RVol`/`RBeta`
+  in `roll.bqn`, and `VolTarget` in `risk.bqn`.
 - Genuinely path-dependent windows (`RMaxDD`, `RMax`/`RMin`) stay windowed —
   there is no clean prefix-sum form.
 - Hoist loop-invariant computations out of `˘`/`¨` bodies.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,113 @@
-../CLAUDE.md
+# CLAUDE.md
+
+Guidance for working in the **bbq** (BQN Based Quant) codebase. Read this
+before changing engine code or docs.
+
+## What this is
+
+A quantitative-finance toolkit written in [BQN](https://mlochbaum.github.io/BQN/),
+run with [CBQN](https://github.com/dzaima/CBQN). Eleven engine modules cover
+indicators, signal composition, backtesting, walk-forward validation, options
+pricing, Monte Carlo simulation, rolling analytics, risk controls, execution
+realism, anti-overfitting diagnostics, and multi-asset universe management.
+
+There are no third-party dependencies. The only runtime requirement is the
+`bqn` interpreter on `PATH`.
+
+## Commands
+
+```bash
+make test            # run the full suite (tests/verify.bqn) — must stay green
+make run name=X      # run examples/X.bqn
+make new name=X      # scaffold examples/X.bqn from the template
+make clean           # remove data/*.csv
+```
+
+Run a single file directly: `bqn examples/ma_cross.bqn`. Examples expect a CSV
+at `data/spy.csv` (`Date,Open,High,Low,Close,Volume`, 3 header lines — yfinance
+layout); `data/` is gitignored.
+
+## Architecture
+
+```
+core.bqn ← bt.bqn ← wf.bqn        # the import spine; each re-exports the layer below
+```
+
+- **Strategies import `bt.bqn`**; **walk-forward scripts import `wf.bqn`**.
+  Both re-export everything beneath them, so a strategy never needs `core.bqn`
+  directly.
+- **Leaf modules** — `cmp`, `opt`, `mc`, `roll`, `risk`, `ovf`, `exec`, `uni`
+  — import `bt.bqn` or `core.bqn` and are imported à la carte by scripts.
+
+When you add a public name to `core`/`bt`, add it to the re-export `⟨…⟩ ⇐`
+blocks at the top of `bt.bqn` and `wf.bqn`, or it won't be visible downstream.
+
+## Design model
+
+A backtest is a fold. Indicators are array operations. Positions are arrays of
+`1` (long), `0` (flat), `¯1` (short); the engine multiplies positions by
+returns. Two phases:
+
+1. **Indicators** — pure, vectorized array ops (SIMD-friendly).
+2. **Execution** — compound-state scans, inherently sequential.
+
+`_Sim` threads bar-by-bar state for strategies that need it (trailing stops,
+regime filters) and emits a position array that feeds the same `Run` pipeline.
+
+## Conventions
+
+- **Comment tags**: `# TODO:`, `# NOTE:`, `# BUG:`, `# FIX:`, `# HACK:`,
+  `# PERF:`, `# WARNING:`.
+- **Section dividers**: `# ── Name ─────────────────────────────`.
+- **Assignment**: `←` for first definition, `↩` for reassignment.
+- **Division guards**: clamp the denominator with `eps⌈x` (max), never `eps+x`.
+  The canonical `eps ← 1e¯10` and `tdy ← 252` live in `core.bqn`.
+- **No lookahead**: every backtest position must be lagged one bar before it
+  multiplies returns (`(¯1↓pos)‿(1↓ret)`). Expanding-window stats (`ENorm`)
+  are preferred over full-array ones (`Norm`) for anything that goes live.
+
+## Idiomatic style
+
+- **Prefer trains/forks** for pure, point-free functions — e.g.
+  `Cross ⇐ ≥ ∧ <○»`, `Cost ⇐ ×⟜(|∘-⟜»)`. Reach for an explicit `{…}` block
+  only when it genuinely reads better.
+- **Keep explicit blocks for stateful functions** — `_Sim`, `Hold`, `Fill`,
+  the stop/take-profit family, `CircuitBreaker`, `Drawdowns`. Per-bar state
+  mutation via sequential `¨` with `↩` is clearer than forcing a fork.
+- **Capitalization carries role**: capitalized names are functions, lowercase
+  are subjects, leading `_` are 1-modifiers, leading/trailing `_…_` are
+  2-modifiers. Naming fights the parser if you ignore this.
+
+## Performance
+
+The indicator and rolling layers should be **O(n)**, not O(n·window):
+
+- Rolling sums/means/variances use **prefix sums** (`cs ← 0∾+`x`, then window
+  sum `= (n↓cs) - (-n)↓cs`). See `MA`/`Std` in `core.bqn` and `RSharpe`/`RVol`/
+  `RBeta` in `roll.bqn`, `VolTarget` in `risk.bqn`. Sample variance is
+  `(Σx² - (Σx)²/n)/(n-1)`; clamp with `√0⌈…` to absorb cancellation noise.
+- Genuinely path-dependent windows (`RMaxDD`, `RMax`/`RMin`) stay windowed —
+  there is no clean prefix-sum form.
+- Hoist loop-invariant computations out of `˘`/`¨` bodies.
+
+When you touch a hot path, sanity-check the rewrite against the previous
+implementation on random data (max abs diff well under `1e¯6`) before relying
+on the test suite.
+
+## Data contract
+
+`Load path` returns a namespace `{dates, close, high, low, open, vol}` of
+equal-length flat float arrays. `Validate` enforces finiteness, OHLC
+relationships, and (strict mode) positivity; pass `0` as `𝕨` for futures mode
+to allow negative prices. Any source that produces this shape works.
+
+## Adding a module
+
+1. Place it in `engine/`, import `bt.bqn` (or `core.bqn` for a leaf).
+2. Export the public API with `⇐`; keep internals on `←`.
+3. Add tests to `tests/verify.bqn` (every public export needs coverage).
+4. Document the API in `README.md` and update this file if conventions shift.
+5. Add an `examples/` script if the module has a natural usage pattern.
+
+Use Conventional Commits (`feat`, `fix`, `docs`, `refactor`, `test`, `chore`,
+`perf`). Keep `make test` green.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ PRs are welcome. Open an issue first for anything non-trivial so we can align on
 Target `main` directly. Small, focused PRs are easier to review.
 
 Checklist before opening:
-- `make test` passes (129 tests)
+- `make test` passes (134 tests)
 - New exports have tests in `tests/verify.bqn`
 - `CLAUDE.md` updated if you added or changed any exported API
 - Conventional commit message (`feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ v2.0
 
 ## Overview
 
-bbq is a quantitative finance toolkit in [BQN](https://mlochbaum.github.io/BQN/). 11 modules: indicators, backtesting, walk-forward validation, options pricing, Monte Carlo simulation, risk management, and anti-overfitting diagnostics.
+bbq is a quantitative finance toolkit in [BQN](https://mlochbaum.github.io/BQN/). 11 modules: indicators, signal composition, backtesting, walk-forward validation, options pricing, Monte Carlo simulation, rolling analytics, risk management, execution realism, anti-overfitting diagnostics, and multi-asset universe management.
 
 ## BQN 101
 
@@ -89,7 +89,7 @@ Or export from your broker.
 ```
 make new name=X        Create strategy from template
 make run name=X        Run a strategy
-make test              Run test suite (129 tests)
+make test              Run test suite (134 tests)
 make clean             Remove data files
 ```
 
@@ -183,6 +183,8 @@ paths ← mc.Paths 10000‿100‿0.05‿0.2‿1‿252   # 10k GBM paths
 price ← 100⊸mc.EuroCall mc._Price paths‿0.05‿1
 # Antithetic variance reduction
 apaths ← mc.Paths mc._Antithetic 5000‿100‿0.05‿0.2‿1‿252
+# Fat tails: Student's t innovations (ν=5)
+tpaths ← mc.TPaths 10000‿100‿0.05‿0.2‿1‿252‿5
 ```
 
 ### Risk Management
@@ -313,12 +315,16 @@ All take returns, return a number. Trades/TimeIn/Exposure take positions.
 | `IV` | `IV target‿S‿K‿T‿r‿type` | Implied volatility (Newton-Raphson) |
 | `Parity` | `Parity S‿K‿T‿r` | Put-call parity forward |
 | `Npdf` / `Phi` / `PhiInv` | Monadic | Normal distribution functions |
+| `Tpdf` / `Tcdf` | `ν Tpdf x` | Student's t PDF / CDF |
+| `TcdfInv` | `ν TcdfInv p` | Inverse Student's t CDF (Newton-Raphson) |
 
 ### Monte Carlo
 
 | Name | Signature | Description |
 |------|-----------|-------------|
 | `Paths` | `Paths n‿S₀‿μ‿σ‿T‿steps` | GBM price paths [n, steps] |
+| `TPaths` | `TPaths n‿S₀‿μ‿σ‿T‿steps‿ν` | Fat-tailed GBM paths (Student's t) |
+| `RandT` | `ν RandT n` | n Student's t samples |
 | `_Price` | `Payoff _Price paths‿r‿T` | Discounted expected payoff |
 | `_Antithetic` | `Paths _Antithetic config` | Antithetic variance reduction |
 | `EuroCall` / `EuroPut` | `k F path` | European payoffs |
@@ -348,6 +354,7 @@ All take returns, return a number. Trades/TimeIn/Exposure take positions.
 | `MaxPos` | `cap MaxPos pos` | Clip magnitude, preserve sign |
 | `CircuitBreaker` | `n‿thresh CircuitBreaker pos‿ret` | Pause on cumulative loss |
 | `DDControl` | `thresh DDControl pos‿ret` | Pause on drawdown |
+| `Scale` | `arr Scale pos` | Element-wise position scaling |
 
 ### Anti-Overfitting
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,16 @@ weights ← 2 uni.TopN scores        # long top-2, short bottom-2
 
 `Load` returns a namespace: `{dates⇐, close⇐, high⇐, low⇐, open⇐, vol⇐}`. All numeric arrays are flat floats, same length. Any data source that returns this shape works with bbq.
 
+| Name | Signature | Description |
+|------|-----------|-------------|
+| `Load` | `Load path` | Parse a CSV into the data namespace |
+| `Validate` | `Validate data` | Enforce finiteness & OHLC relations (`0 Validate` = futures mode) |
+| `LoadMany` | `LoadMany paths` | Load several CSVs, tail-aligned to the shortest |
+| `Align` | `Align arrays` | Tail-align a list of arrays to the shortest |
+| `AlignDates` | `AlignDates datasets` | Tail-align a list of data namespaces |
+
+Also exported for reuse: the constants `eps` (`1e¯10`) and `tdy` (`252`), and the helpers `Split` (CSV tokenizer), `Wilder` (smoothing), and `Pstd` (population std).
+
 ### Indicators
 
 All dyadic: `n Indicator prices` unless noted. Output is shorter than input by the warmup period. EMA returns same length.
@@ -279,6 +289,23 @@ positions. Note `cmp.Thresh` differs from the `Thresh` above: it maps scores to
 | `Score` | `weights Score features` | Weighted sum with auto-alignment |
 | `Thresh` | `level Thresh scores` | Map score to position `1`/`0`/`¯1` |
 | `Compose` | `weights‿level Compose features` | Norm → Score → Thresh (full-array; lookahead) |
+
+### Backtest
+
+The core fold: lag positions one bar, multiply by returns, subtract costs.
+
+| Name | Signature | Description |
+|------|-----------|-------------|
+| `Ret` | `Ret prices` | Simple returns (1 shorter than input) |
+| `LogRet` | `LogRet prices` | Log returns (1 shorter than input) |
+| `Run` | `pos Run ret` | Strategy returns (`pos × ret`) |
+| `RunOHLC` | `pos RunOHLC data` | Open-to-open execution returns |
+| `Cost` | `rate Cost pos` | Per-bar transaction-cost array |
+| `Equity` | `Equity ret` | Equity curve from returns (starts at 1) |
+| `_Sim` | `Step _Sim init‿obs` | Thread bar-by-bar state into a position array |
+| `Report` | `name‿pos Report strat‿bh` | Print a strategy-vs-benchmark summary |
+
+Reporting helpers (also exported): `Pct` (signed percent), `Rd` (2-dp round), `Pad` (right-pad to width).
 
 ### Metrics
 

--- a/README.md
+++ b/README.md
@@ -266,6 +266,20 @@ All dyadic: `n Indicator prices` unless noted. Output is shorter than input by t
 | `ThreshDown` | `level ThreshDown values` | 1 where value crosses below level |
 | `Hold` | `n Hold positions` | Min n-bar holding period |
 
+### Composition
+
+Signal-fusion layer (`cmp.bqn`). Normalize features, blend into a score, map to
+positions. Note `cmp.Thresh` differs from the `Thresh` above: it maps scores to
+`1`/`0`/`¯1` rather than emitting crossing signals.
+
+| Name | Signature | Description |
+|------|-----------|-------------|
+| `Norm` | `Norm arr` | Z-score, full-array (per-fold use) |
+| `ENorm` | `ENorm arr` | Expanding-window z-score (no lookahead) |
+| `Score` | `weights Score features` | Weighted sum with auto-alignment |
+| `Thresh` | `level Thresh scores` | Map score to position `1`/`0`/`¯1` |
+| `Compose` | `weights‿level Compose features` | Norm → Score → Thresh (full-array; lookahead) |
+
 ### Metrics
 
 All take returns, return a number. Trades/TimeIn/Exposure take positions.

--- a/engine/cmp.bqn
+++ b/engine/cmp.bqn
@@ -18,12 +18,8 @@ ENorm ⇐ {
 
 # ── Scoring ────────────────────────────────────
 
-# weights Score features — weighted sum with auto-alignment
-Score ⇐ {
-  maxlen←⌈´≠¨𝕩 ⋄ f←bt.Align 𝕩
-  {maxlen>≠0⊑f ? •Out "cmp: trimming features to "∾(•Fmt ≠0⊑f)∾" bars" ; @}
-  𝕨+˝∘×>f
-}
+# weights Score features — weighted sum, features auto-aligned to shortest length
+Score ⇐ {f←bt.Align 𝕩 ⋄ 𝕨+˝∘×>f}
 
 # ── Thresholding ───────────────────────────────
 

--- a/engine/core.bqn
+++ b/engine/core.bqn
@@ -99,7 +99,8 @@ EMA ⇐ {
 # n WMA prices — weighted moving average
 WMA ⇐ {
   w ← 1+↕𝕨
-  {(+´w×𝕩)÷+´w}˘ 𝕨↕𝕩
+  sw ← +´w  # PERF: hoist constant weight sum out of the per-window reduction
+  {(+´w×𝕩)÷sw}˘ 𝕨↕𝕩
 }
 
 # n Std prices — rolling population standard deviation, O(n) via prefix-sum

--- a/engine/mc.bqn
+++ b/engine/mc.bqn
@@ -2,7 +2,6 @@
 # engine/mc.bqn — Monte Carlo simulation
 
 core ← •Import "core.bqn"
-opt ← •Import "opt.bqn"
 eps ← core.eps
 
 # ── RNG (internal) ─────────────────────────────
@@ -25,18 +24,6 @@ RandChi2 ← {+˝ (𝕨‿𝕩 ⥊ Randn 𝕨×𝕩) ⋆ 2}
 
 # nu RandT n → n Student's t samples
 RandT ⇐ {(Randn 𝕩) ÷ √(𝕨 RandChi2 𝕩)÷𝕨}
-
-# ── Formatting (internal) ──────────────────────
-
-# Rd4 — round to 4 decimal places
-Rd4 ← {
-  v ← ⌊0.5+10000×|𝕩
-  d ← ¯4↑"0000"∾•Fmt 10000|v
-  ((𝕩<0)/"-") ∾ (•Fmt ⌊v÷10000) ∾ "." ∾ d
-}
-
-# LPad — left-pad string to width (right-align)
-LPad ← (' '⥊˜⊣-≠∘⊢) ∾ ⊢
 
 # ── Path Generation ────────────────────────────
 

--- a/engine/ovf.bqn
+++ b/engine/ovf.bqn
@@ -5,7 +5,6 @@ bt  ← •Import "bt.bqn"
 opt ← •Import "opt.bqn"
 
 eps ← bt.eps
-tdy ← bt.tdy
 
 # ── Helpers ──────────────────────────────────
 

--- a/engine/risk.bqn
+++ b/engine/risk.bqn
@@ -9,15 +9,15 @@ tdy ← bt.tdy
 
 # target VolTarget sig‿ret → scaled position to achieve target annualized vol
 # Uses 21-bar rolling sample std (N-1), annualized by √252
+# PERF: O(n) via prefix sums (sample variance = (Σx² - (Σx)²/n)/(n-1))
 VolTarget ⇐ {
   target ← 𝕨
   sig‿ret ← 𝕩
   n ← 21
-  rvol ← {
-    w ← ret⊏˜(𝕩-(n-1))+↕n
-    m ← (+´w)÷n
-    (√(+´(w-m)⋆2)÷((n-1)⌈1)) × √tdy
-  }¨ (n-1)+↕((≠ret)-(n-1))
+  cs1 ← 0∾+`ret ⋄ cs2 ← 0∾+`ret⋆2
+  s1 ← (n↓cs1) - (-n)↓cs1
+  s2 ← (n↓cs2) - (-n)↓cs2
+  rvol ← (√0⌈(s2 - (s1⋆2)÷n)÷(n-1)⌈1) × √tdy
   scaled ← ((n-1)↓sig) × target ÷ rvol⌈eps
   ((n-1)⥊0) ∾ scaled
 }

--- a/engine/roll.bqn
+++ b/engine/roll.bqn
@@ -5,27 +5,26 @@ bt ← •Import "bt.bqn"
 
 # ── Rolling Metrics ──────────────────────────
 
+# Internal: rolling window sums via prefix-sum, O(n). Length (≠𝕩)-𝕨+1.
+Wsum ← {cs←0∾+`𝕩 ⋄ (𝕨↓cs) - (-𝕨)↓cs}
+
 # n RSharpe ret → rolling n-bar annualized Sharpe (sample std N-1)
+# PERF: O(n) via prefix sums (sample variance = (Σx² - (Σx)²/n)/(n-1))
 RSharpe ⇐ {
   n←𝕨 ⋄ r←𝕩
-  samp ← {
-    w ← r⊏˜(𝕩-(n-1))+↕n
-    m ← (+´w)÷n
-    s ← √(+´(w-m)⋆2)÷(n-1)⌈1
-    (√bt.tdy) × m ÷ s⌈bt.eps
-  }¨ (n-1)+↕((≠r)-(n-1))
-  ((n-1)⥊0) ∾ samp
+  s1 ← n Wsum r ⋄ s2 ← n Wsum r⋆2
+  m ← s1÷n
+  s ← √0⌈(s2 - s1×m)÷(n-1)⌈1
+  ((n-1)⥊0) ∾ (√bt.tdy) × m ÷ s⌈bt.eps
 }
 
 # n RVol ret → rolling n-bar annualized vol (sample std N-1)
+# PERF: O(n) via prefix sums
 RVol ⇐ {
   n←𝕨 ⋄ r←𝕩
-  samp ← {
-    w ← r⊏˜(𝕩-(n-1))+↕n
-    m ← (+´w)÷n
-    (√((+´(w-m)⋆2)÷(n-1)⌈1)) × √bt.tdy
-  }¨ (n-1)+↕((≠r)-(n-1))
-  ((n-1)⥊0) ∾ samp
+  s1 ← n Wsum r ⋄ s2 ← n Wsum r⋆2
+  v ← (s2 - (s1⋆2)÷n)÷(n-1)⌈1
+  ((n-1)⥊0) ∾ (√0⌈v) × √bt.tdy
 }
 
 # n RMaxDD ret → rolling max drawdown over n-bar window
@@ -41,18 +40,15 @@ RMaxDD ⇐ {
 }
 
 # n‿bench RBeta strat → rolling n-bar beta vs benchmark
+# PERF: O(n) via prefix sums (cov = (Σsb - Σs·Σb/n)/(n-1))
 RBeta ⇐ {
   n‿bench ← 𝕨
   b‿s ← bt.Align bench‿𝕩
-  beta ← {
-    ws ← s⊏˜(𝕩-(n-1))+↕n
-    wb ← b⊏˜(𝕩-(n-1))+↕n
-    ms ← (+´ws)÷n ⋄ mb ← (+´wb)÷n
-    cov ← (+´(ws-ms)×(wb-mb))÷(n-1)⌈1
-    var ← (+´(wb-mb)⋆2)÷(n-1)⌈1
-    cov÷var⌈bt.eps
-  }¨ (n-1)+↕((≠s)-(n-1))
-  ((n-1)⥊0) ∾ beta
+  ws ← n Wsum s ⋄ wb ← n Wsum b
+  wbb ← n Wsum b⋆2 ⋄ wsb ← n Wsum b×s
+  cov ← (wsb - (ws×wb)÷n)÷(n-1)⌈1
+  var ← (wbb - (wb⋆2)÷n)÷(n-1)⌈1
+  ((n-1)⥊0) ∾ cov÷var⌈bt.eps
 }
 
 # ── Scalar Metrics ───────────────────────────


### PR DESCRIPTION
## Summary

A performance + housekeeping refresh, taken all the way to pedant-proof. No public API changes; `make test` stays green at **134/134**.

Four threads:
1. **Perf** — make the rolling-statistics layer O(n) instead of O(n·window).
2. **Cleanup** — remove genuine dead code; restore a broken doc symlink; drop a stray stdout side effect.
3. **Docs** — close every gap between what the engine exports and what the README/CLAUDE.md document.
4. **Hygiene** — no trailing whitespace, no tabs, final newlines, every public export documented.

## Performance

`roll.RSharpe`, `roll.RVol`, `roll.RBeta`, and `risk.VolTarget` recomputed every window from scratch (O(n·window)), even though `core.MA`/`core.Std` already demonstrate the O(n) prefix-sum technique. Rewrote them in single-pass prefix-sum form (sample variance via the `(Σx² − (Σx)²/n)/(n−1)` identity, clamped with `√0⌈…` to absorb cancellation noise). Also hoisted a loop-invariant weight sum out of `core.WMA`.

Measured with CBQN, 200k rows, window 60:

| Function | Before | After | Speedup |
|---|--:|--:|--:|
| `RSharpe` | 305 ms | 7 ms | ~45× |
| `RVol` | 288 ms | 9 ms | ~31× |
| `RBeta` | 375 ms | 12 ms | ~32× |
| `VolTarget` | 127 ms | 10 ms | ~13× |

Now independent of window size, so the gap widens as windows grow.

**Correctness:** diffed each rewrite against the previous implementation on 50k rows of random data — max abs diff **~1e⁻¹²** (`WMA` bit-identical), far under the suite's `1e⁻⁶` tolerance. Path-dependent windows (`RMaxDD`, `RMax`/`RMin`) have no clean prefix-sum form and were intentionally left windowed.

## Cleanup

- `engine/mc.bqn`: drop an unused `opt` import and the internal `Rd4`/`LPad` formatters (the convergence example carries its own copies; nothing in the module used them).
- `engine/ovf.bqn`: drop the unused `tdy` binding.
- `engine/cmp.bqn`: `Score` wrote a "trimming features" warning to **stdout** — a side effect in an otherwise-pure primitive whose contract is already to auto-align. Removed; it now aligns and weights silently.
- `CLAUDE.md`: was a **dangling symlink** to `../CLAUDE.md` (outside the repo) — broken for anyone cloning, yet `CONTRIBUTING.md` cites it as the canonical conventions doc. Replaced with a real file covering architecture, conventions, idiomatic style, the prefix-sum performance pattern, and the data contract.

## Docs

- README: added a **Backtest** API table (`Ret`, `LogRet`, `Run`, `RunOHLC`, `Cost`, `Equity`, `_Sim`, `Report`) and a **Data Contract** table (`Load`, `Validate`, `LoadMany`, `Align`, `AlignDates`) — these verbs appear in every example but had no API entry. Added the **Composition** (`cmp`) table, the Student's t API (`opt.Tpdf`/`Tcdf`/`TcdfInv`, `mc.TPaths`/`RandT`), `risk.Scale`, the exported constants/helpers (`eps`, `tdy`, `Split`, `Wilder`, `Pstd`), and reporting helpers (`Pct`, `Rd`, `Pad`). **Every public export is now documented.**
- Corrected the test count (129 → **134**) in README and CONTRIBUTING; expanded the Overview module list to match the architecture.
- Fixed a markdown rendering bug in CLAUDE.md where BQN's scan (a backtick) broke inline-code delimiters.

## Verification

- `make test` → **All 134 tests passed**
- All three `examples/` run end-to-end against synthetic data
- Old-vs-new numerical diff on 50k random rows: max abs diff ~1e⁻¹²
- Export-vs-docs cross-check: 0 undocumented public exports
- Whitespace/tab/EOF sweep: clean
- Benchmark claims in the README are backed by the reproducible harness on the `bench` branch; the modules touched here are outside that suite, so no published numbers are affected.

https://claude.ai/code/session_01T8H29PrrSkj3kxrBWRRoGh